### PR TITLE
rpc: added samples rpc to communicate between frames

### DIFF
--- a/packages/iframe-source-website/lib/event.subject.ts
+++ b/packages/iframe-source-website/lib/event.subject.ts
@@ -1,0 +1,24 @@
+// todo: move to app-shell
+export class EventSubject<T, F extends (event: T) => void = (event: T) => void> {
+  private subscribers = new Set<F>();
+
+  emit(event: T): void {
+    for (const fn of this.subscribers) {
+      if (fn.call) {
+        fn(event);
+      }
+    }
+  }
+
+  subscribe(fn: F): void {
+    if (!this.subscribers.has(fn)) {
+      this.subscribers.add(fn);
+    }
+  }
+
+  unsubscribe(fn: F): void {
+    if (this.subscribers.has(fn)) {
+      this.subscribers.delete(fn);
+    }
+  }
+}

--- a/packages/iframe-source-website/lib/rpc.connector.ts
+++ b/packages/iframe-source-website/lib/rpc.connector.ts
@@ -1,0 +1,9 @@
+// todo: move to app-shell
+import * as bus from 'framebus';
+import {RpcProvider} from 'worker-rpc';
+
+const rpcChannel = 'rpc-action';
+export const rpcProvider = new RpcProvider(
+  (message, transfer) => bus.emit(rpcChannel, message, transfer)
+);
+bus.on(rpcChannel, (event) => rpcProvider.dispatch(event));

--- a/packages/iframe-source-website/lib/theme.consumer.ts
+++ b/packages/iframe-source-website/lib/theme.consumer.ts
@@ -1,0 +1,24 @@
+// todo: move to app-shell
+import { EventSubject } from './event.subject';
+import { rpcProvider } from './rpc.connector';
+
+const ChangeThemeActionName = 'changeTheme';
+const GetDefaultThemeAction = 'getDefaultTheme';
+
+export interface ThemeValue {
+  id: string;
+  name: string;
+  url: string;
+}
+
+const subs = new EventSubject<ThemeValue>();
+export class ThemeConsumer {
+  static themeChanged(callback: (value: ThemeValue) => void): void {
+    subs.subscribe(callback);
+  }
+
+  static getCurrentTheme(callback: (value: ThemeValue) => void): void  {
+    rpcProvider.rpc<void, ThemeValue>(GetDefaultThemeAction).then(callback);
+  }
+}
+rpcProvider.registerRpcHandler(ChangeThemeActionName, (payload: ThemeValue) => subs.emit(payload));

--- a/packages/iframe-source-website/package-lock.json
+++ b/packages/iframe-source-website/package-lock.json
@@ -1697,6 +1697,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@braintree/uuid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@braintree/uuid/-/uuid-0.1.0.tgz",
+      "integrity": "sha512-YvZJdlNcK5EnR+7M8AjgEAf4Qx696+FOSYlPfy5ePn80vODtVAUU0FxHnzKZC0og1VbDNQDDiwhthR65D4Na0g=="
+    },
     "@fundamental-ngx/app-shell": {
       "version": "0.2.21",
       "resolved": "https://registry.npmjs.org/@fundamental-ngx/app-shell/-/app-shell-0.2.21.tgz",
@@ -5548,6 +5553,14 @@
         "map-cache": "^0.2.2"
       }
     },
+    "framebus": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/framebus/-/framebus-4.0.4.tgz",
+      "integrity": "sha512-2QssyHaq7KpErcrU+jVYBPfRU4NIoisV3R30Vv5AP6+QpdCMfu3S3uZH/DpwrDVzYkfb5f9w63ZTcnPq7VXXiw==",
+      "requires": {
+        "@braintree/uuid": "^0.1.0"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7803,6 +7816,11 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
+    },
+    "microevent.ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.2.1.tgz",
+      "integrity": "sha512-YaOQr4V70QzTy3sTRkBUa7+clmN4rMdKs9L5wCCxYjo8gknO/FXhcEX5Pot4IWtAdiZqhxN7vskoywQbAOAkDQ=="
     },
     "micromatch": {
       "version": "4.0.2",
@@ -13796,6 +13814,14 @@
             "json5": "^1.0.1"
           }
         }
+      }
+    },
+    "worker-rpc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.2.0.tgz",
+      "integrity": "sha512-S74HnfAdmMlUYmr6+Lx6TmxvffM2vRZSk4RfI/Bxco4xZGw+FREzLRZhFxf8QIzI2/5NKNMn5+Pj69Bp+rweIg==",
+      "requires": {
+        "microevent.ts": "~0.2.1"
       }
     },
     "wrap-ansi": {

--- a/packages/iframe-source-website/package.json
+++ b/packages/iframe-source-website/package.json
@@ -25,11 +25,13 @@
     "@pscoped/ngx-pub-sub": "3.0.0",
     "@sap-theming/theming-base-content": "11.1.20",
     "concurrently": "^5.2.0",
+    "framebus": "^4.0.4",
     "fundamental-styles": "^0.12.0",
     "json-stringify": "^1.0.0",
     "mini-css-extract-plugin": "^0.9.0",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.1",
+    "worker-rpc": "^0.2.0",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {

--- a/packages/iframe-source-website/src/app/app.component.html
+++ b/packages/iframe-source-website/src/app/app.component.html
@@ -1,14 +1,17 @@
-<div class="my-page">
-  <h4>Quick Links</h4>
-  <hr/>
-  <a fd-link (click)="onAction($event, 'Request Non-catalog Item')">
-    <fd-icon size="s" glyph="activity-items"></fd-icon>
-    Request Non-catalog Item</a><br/><br/>
+<link *ngIf="themeSrc" [href]="themeSrc" rel="stylesheet"/>
+<div class="fd-has-display-block">
+  <fd-layout-panel-body>
+    <h4>Quick Links</h4>
+    <hr/>
+    <a fd-link (click)="onAction($event, 'Request Non-catalog Item')">
+      <fd-icon size="s" glyph="activity-items"></fd-icon>
+      Request Non-catalog Item</a><br/><br/>
 
-  <a fd-link href="">
-    <fd-icon size="s" glyph="batch-payments"></fd-icon>
-    Request By Plant</a><br/><br/>
-  <a fd-link href="">
-    <fd-icon size="s" glyph="cart"></fd-icon>
-    Create Project</a><br/><br/>
+    <a fd-link href="">
+      <fd-icon size="s" glyph="batch-payments"></fd-icon>
+      Request By Plant</a><br/><br/>
+    <a fd-link href="">
+      <fd-icon size="s" glyph="cart"></fd-icon>
+      Create Project</a><br/><br/>
+  </fd-layout-panel-body>
 </div>

--- a/packages/iframe-source-website/src/app/app.component.scss
+++ b/packages/iframe-source-website/src/app/app.component.scss
@@ -1,5 +1,0 @@
-.my-page {
-  display:block;
-  width: 100%;
-  height: 100%;
-}

--- a/packages/iframe-source-website/src/app/app.component.ts
+++ b/packages/iframe-source-website/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { ThemeConsumer, ThemeValue } from '../../lib/theme.consumer';
 
 @Component({
   selector: 'app-root',
@@ -7,11 +9,15 @@ import { Component, OnDestroy } from '@angular/core';
 })
 export class AppComponent implements OnDestroy {
   title = 'iframe-source-app';
+  themeSrc?: SafeUrl;
 
-  constructor() {
+  constructor(domSanitizer: DomSanitizer) {
     if (window.addEventListener) {
       window.addEventListener('message', this.onMessage, false);
     }
+    const updateTheme = (theme: ThemeValue) => this.themeSrc = domSanitizer.bypassSecurityTrustResourceUrl(theme.url);
+    ThemeConsumer.getCurrentTheme(updateTheme);
+    ThemeConsumer.themeChanged(updateTheme);
   }
 
   onAction(event: any, msg: string): void {

--- a/packages/iframe-source-website/src/index.html
+++ b/packages/iframe-source-website/src/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>ContentReqApp</title>
+  <title>IframeSource</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+<!--  <link href="https://unpkg.com/fundamental-styles@latest/dist/fundamental-styles.css" rel="stylesheet">-->
+  <link href="https://sap.github.io/fundamental-ngx/styles.1aa62a8b4b599ef5e758.css" rel="stylesheet">
+  <link href="https://unpkg.com/fundamental-styles@0.12.0/dist/layout-panel.css" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/packages/iframe-source-website/src/styles.scss
+++ b/packages/iframe-source-website/src/styles.scss
@@ -47,7 +47,5 @@ body {
 }
 
 body {
-  margin: 0;
-  background-color: white;
-  font-family: "72", sans-serif;
+  background-color: transparent;
 }

--- a/packages/iframe-source-website/tsconfig.json
+++ b/packages/iframe-source-website/tsconfig.json
@@ -15,7 +15,8 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "enableIvy": true,

--- a/packages/one-bx-shell-app/package-lock.json
+++ b/packages/one-bx-shell-app/package-lock.json
@@ -1697,6 +1697,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@braintree/uuid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@braintree/uuid/-/uuid-0.1.0.tgz",
+      "integrity": "sha512-YvZJdlNcK5EnR+7M8AjgEAf4Qx696+FOSYlPfy5ePn80vODtVAUU0FxHnzKZC0og1VbDNQDDiwhthR65D4Na0g=="
+    },
     "@fundamental-ngx/app-shell": {
       "version": "0.2.21",
       "resolved": "https://registry.npmjs.org/@fundamental-ngx/app-shell/-/app-shell-0.2.21.tgz",
@@ -5543,6 +5548,14 @@
         "map-cache": "^0.2.2"
       }
     },
+    "framebus": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/framebus/-/framebus-4.0.4.tgz",
+      "integrity": "sha512-2QssyHaq7KpErcrU+jVYBPfRU4NIoisV3R30Vv5AP6+QpdCMfu3S3uZH/DpwrDVzYkfb5f9w63ZTcnPq7VXXiw==",
+      "requires": {
+        "@braintree/uuid": "^0.1.0"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7798,6 +7811,11 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
+    },
+    "microevent.ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.2.1.tgz",
+      "integrity": "sha512-YaOQr4V70QzTy3sTRkBUa7+clmN4rMdKs9L5wCCxYjo8gknO/FXhcEX5Pot4IWtAdiZqhxN7vskoywQbAOAkDQ=="
     },
     "micromatch": {
       "version": "4.0.2",
@@ -13791,6 +13809,14 @@
             "json5": "^1.0.1"
           }
         }
+      }
+    },
+    "worker-rpc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.2.0.tgz",
+      "integrity": "sha512-S74HnfAdmMlUYmr6+Lx6TmxvffM2vRZSk4RfI/Bxco4xZGw+FREzLRZhFxf8QIzI2/5NKNMn5+Pj69Bp+rweIg==",
+      "requires": {
+        "microevent.ts": "~0.2.1"
       }
     },
     "wrap-ansi": {

--- a/packages/one-bx-shell-app/package.json
+++ b/packages/one-bx-shell-app/package.json
@@ -25,10 +25,12 @@
     "@pscoped/ngx-pub-sub": "3.0.0",
     "@sap-theming/theming-base-content": "11.1.20",
     "concurrently": "^5.2.0",
+    "framebus": "^4.0.4",
     "json-stringify": "^1.0.0",
     "mini-css-extract-plugin": "^0.9.0",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.1",
+    "worker-rpc": "^0.2.0",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {

--- a/packages/one-bx-shell-app/src/app/app.component.ts
+++ b/packages/one-bx-shell-app/src/app/app.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {ProductSwitchItem, ShellbarMenuItem, ShellbarUser, ShellbarUserMenu} from '@fundamental-ngx/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {AppShellProviderService, Message} from '@fundamental-ngx/app-shell';
+import { ThemeProvider } from '../lib/theme.provider';
 
 @Component({
   selector: 'app-root',
@@ -162,6 +163,7 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     this._cssUrl = this.sanitizer.bypassSecurityTrustResourceUrl('assets/theme/sap_fiori_3.css');
     this._appShell.themeManager.themeChanged(this.themes[0].id, this.themes[0].name);
+    ThemeProvider.setCurrentTheme({...this.themes[0], url: `${location.href}assets/theme/sap_fiori_3.css`});
   }
 
 
@@ -192,10 +194,11 @@ export class AppComponent implements OnInit {
   onSelectTheme(id: string, name: string): void {
     this._cssUrl = this.sanitizer.bypassSecurityTrustResourceUrl('assets/theme/' + id + '.css');
     this._appShell.themeManager.themeChanged(id, name);
+    ThemeProvider.changeTheme({id, name, url: `${location.href}assets/theme/${id}.css`});
   }
 
   onAppEvent(m: Message): void {
-    console.log('AppShell received => ', m)
+    console.log('AppShell received => ', m);
   }
 
 }

--- a/packages/one-bx-shell-app/src/index.html
+++ b/packages/one-bx-shell-app/src/index.html
@@ -8,6 +8,7 @@
   <link href="favicon.ico" rel="icon" type="image/x-icon">
   <link href="https://unpkg.com/@angular/cdk/overlay-prebuilt.css" rel="stylesheet">
   <link href="https://sap.github.io/fundamental-ngx/styles.1aa62a8b4b599ef5e758.css" rel="stylesheet">
+<!--  <link href="https://unpkg.com/fundamental-styles@latest/dist/fundamental-styles.css" rel="stylesheet">-->
   <style>
 
     html,

--- a/packages/one-bx-shell-app/src/lib/rpc.connector.ts
+++ b/packages/one-bx-shell-app/src/lib/rpc.connector.ts
@@ -1,0 +1,10 @@
+// todo: move to app-shell
+import * as bus from 'framebus';
+import {RpcProvider} from 'worker-rpc';
+
+const rpcChannel = 'rpc-action';
+export const rpcProvider = new RpcProvider(
+  (message, transfer) => bus.emit(rpcChannel, message, transfer)
+);
+bus.on(rpcChannel, (event) => rpcProvider.dispatch(event));
+

--- a/packages/one-bx-shell-app/src/lib/theme.provider.ts
+++ b/packages/one-bx-shell-app/src/lib/theme.provider.ts
@@ -1,0 +1,27 @@
+// todo: move to app-shell
+import {rpcProvider} from './rpc.connector';
+
+const ChangeThemeAction = 'changeTheme';
+const GetDefaultThemeAction = 'getDefaultTheme';
+
+interface ThemeValue {
+  id: string;
+  name: string;
+  url: string;
+}
+
+let defaultTheme;
+rpcProvider.registerRpcHandler(GetDefaultThemeAction, () => defaultTheme);
+export class ThemeProvider {
+  static setCurrentTheme(value: ThemeValue): void {
+    defaultTheme = value;
+  }
+
+  static changeTheme(value: ThemeValue): void {
+    defaultTheme = value;
+    rpcProvider.rpc<ThemeValue>(ChangeThemeAction, value)
+      // todo: when moved to app-shell should be replaced with Logger
+      .then(console.info.bind(console))
+      .catch(console.error.bind(console));
+  }
+}

--- a/packages/one-bx-shell-app/tsconfig.json
+++ b/packages/one-bx-shell-app/tsconfig.json
@@ -15,7 +15,8 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "enableIvy": true,


### PR DESCRIPTION
ideas split it 2 parts: consumer and provider
provider provides data 
```ts
// sets persistent value
    ThemeProvider.setCurrentTheme({...this.themes[0], url: `${location.href}assets/theme/sap_fiori_3.css`});
// fires event with event
    ThemeProvider.changeTheme({id, name, url: `${location.href}assets/theme/${id}.css`});
```

consumer consumes :D
```ts
    const updateTheme = (theme: ThemeValue) => this.themeSrc = domSanitizer.bypassSecurityTrustResourceUrl(theme.url);
// get latest value
    ThemeConsumer.getCurrentTheme(updateTheme);
// subscribe to events
    ThemeConsumer.themeChanged(updateTheme);
```

stub for a possible error and communication handling
```ts
  static changeTheme(value: ThemeValue): void {
    defaultTheme = value;
    rpcProvider.rpc<ThemeValue>(ChangeThemeAction, value)
      // todo: when moved to app-shell should be replaced with Logger
      .then(console.info.bind(console))
      .catch(console.error.bind(console));
  }
```

EventSubject is 1to1 contract implementation of angular eventemitter but without rxjs part
rpc.connector.ts is basically a config which connects postMessage to rpc

ThemeConsumers and ThemeProviders is a classes with which developers are supposed to work with
So later on we can replace underlying implementation in any way we like later on