### PR TITLE
added support of ngrx-effects

### DIFF
--- a/mf-builder/webpack.config.js
+++ b/mf-builder/webpack.config.js
@@ -34,7 +34,8 @@ const shellConfig = {
     sharedDep('@angular/router'),
     sharedDep('@fundamental-ngx/core'),
     sharedDep('@fundamental-ngx/app-shell'),
-    sharedDep('@ngrx/store')
+    sharedDep('@ngrx/store'),
+    sharedDep('@ngrx/effects')
   ],
   exposes: {}
 };
@@ -132,7 +133,8 @@ const mfe5Config = {
     sharedDep('@angular/router'),
     sharedDep('@fundamental-ngx/core'),
     sharedDep('@fundamental-ngx/app-shell'),
-    sharedDep('@ngrx/store')
+    sharedDep('@ngrx/store'),
+    sharedDep('@ngrx/effects')
   ],
   exposes: {
     './Counter': '../packages/ngrx-app/src/app/counter/counter.component.ts',

--- a/packages/cflp-app/package-lock.json
+++ b/packages/cflp-app/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cflp-header-app",
+  "name": "cflp-app",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/ngrx-app/package-lock.json
+++ b/packages/ngrx-app/package-lock.json
@@ -1919,6 +1919,14 @@
         }
       }
     },
+    "@ngrx/effects": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-10.0.1.tgz",
+      "integrity": "sha512-pw0hRQNlyBBRHH1NRWl3TF+RtEAS4XOSnoTHPtQ84Ib/bEribvexsdEq3k6yLWvR3tLTudb5J6SYwYawcM6omA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@ngrx/store": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-10.0.0.tgz",

--- a/packages/ngrx-app/package.json
+++ b/packages/ngrx-app/package.json
@@ -21,6 +21,7 @@
     "@angular/router": "~10.1.2",
     "@fundamental-ngx/app-shell": "0.2.28",
     "@fundamental-ngx/core": "0.21.4",
+    "@ngrx/effects": "^10.0.1",
     "@ngrx/store": "^10.0.0",
     "@pscoped/ngx-pub-sub": "3.0.0",
     "@sap-theming/theming-base-content": "11.1.20",

--- a/packages/ngrx-app/src/app/counter/counter-child/counter-child.component.ts
+++ b/packages/ngrx-app/src/app/counter/counter-child/counter-child.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
 import { select, Store, StoreModule } from '@ngrx/store';
-import { AppState, reducers, selectCounterState } from '../../store/app.states';
+
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+
+import { AppState, reducers, selectCounterState } from '../../store/app.states';
 
 @Component({
   selector: 'app-counter-child',

--- a/packages/ngrx-app/src/app/counter/counter.component.ts
+++ b/packages/ngrx-app/src/app/counter/counter.component.ts
@@ -1,26 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, Injector, OnDestroy } from '@angular/core';
 import { select, Store, StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
 
 import { map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 import { AppState, reducers, selectCounterState } from '../store/app.states';
 import { decrement, increment } from '../store/actions';
+import { CounterEffects } from '../store/effects';
 
 @Component({
   selector: 'app-counter',
   templateUrl: './counter.component.html',
   styleUrls: ['./counter.component.scss'],
   providers: [
-    StoreModule.forRoot(reducers, {}).providers
+    StoreModule.forRoot(reducers, {}).providers,
+    EffectsModule.forRoot([CounterEffects]).providers
   ]
 })
-export class CounterComponent {
+export class CounterComponent implements OnDestroy {
   count$: Observable<number>;
 
+  private readonly internalSubscriptions = new Subscription();
+
   constructor(
-    private readonly store: Store<AppState>
+    private readonly store: Store<AppState>,
+    private injector: Injector
   ) {
+    const counterEffects = injector.get(CounterEffects);
+    this.internalSubscriptions.add(
+      counterEffects.increment$.subscribe()
+    );
+
     this.count$ = store.pipe(
       select(selectCounterState),
       map((state: any) => state.counter));
@@ -32,5 +43,9 @@ export class CounterComponent {
 
   decrement() {
     this.store.dispatch(decrement());
+  }
+
+  ngOnDestroy(): void {
+    this.internalSubscriptions.unsubscribe();
   }
 }

--- a/packages/ngrx-app/src/app/store/effects/counter.effects.ts
+++ b/packages/ngrx-app/src/app/store/effects/counter.effects.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+
+import { tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+
+import { CounterActionTypes } from '../actions';
+import { Action } from '@ngrx/store';
+
+@Injectable()
+export class CounterEffects {
+  constructor(
+    private readonly actions: Actions
+  ) {
+  }
+
+  @Effect({dispatch: false})
+  increment$: Observable<Action> =
+    this.actions.pipe(
+      ofType(CounterActionTypes.INCREMENT),
+      tap(() => console.log('Increment$ Effect works!'))
+    );
+}

--- a/packages/ngrx-app/src/app/store/effects/index.ts
+++ b/packages/ngrx-app/src/app/store/effects/index.ts
@@ -1,0 +1,1 @@
+export * from './counter.effects';

--- a/packages/one-bx-shell-app/src/assets/config/plugins.json
+++ b/packages/one-bx-shell-app/src/assets/config/plugins.json
@@ -58,7 +58,8 @@
       {
         "name": "CounterComponent",
         "type": "angular-ivy-component",
-        "exposedModule": "./Counter"
+        "exposedModule": "./Counter",
+        "route": "calc"
       }
     ]
   },


### PR DESCRIPTION
The goal of this task was adding ngrx-effect support and show how to use it in the app.

Steps to use ngrx-effects in the app:

1. to install @ngrx-effects
2. to create Effects class to listen for events and perform tasks.
   Effects are injectable service classes with distinct parts:
- An injectable Actions service that provides an observable stream of all actions dispatched after the latest state has been reduced.
- Metadata is attached to the observable streams using the createEffect function. The metadata is used to register the streams that are subscribed to the store. Any action returned from the effect stream is then dispatched back to the Store.
- Actions are filtered using a pipeable ofType operator. The ofType operator takes one or more action types as arguments to filter on which actions to act upon.
- Effects are subscribed to the Store observable.
- Services are injected into effects to interact with external APIs and handle streams.
3. to use Effects in the app, you need to register Effects in the parent component in _providers_ section of @_Component_, using EffectsModule.forRoot([YourEffect]).providers, then
```
constructor(
    private injector: Injector
  ) {
    const counterEffects = injector.get(CounterEffects);
    this.internalSubscriptions.add(
      counterEffects.increment$.subscribe()
    );
```